### PR TITLE
Udated Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For more information on these outputs, see the [API Documentation](https://devel
 - `id`: The ID of the asset
 - `browser_download_url`: The URL users can navigate to in order to download the release asset. i.e. `https://github.com/octocat/Hello-World/releases/download/v1.0.0/example.zip`
 
-### Example workflow - upload a release asset
+### Example workflow - upload a release asset to a new release
 On every `push` to a tag matching the pattern `v*`, [create a release](https://developer.github.com/v3/repos/releases/#create-a-release) and [upload a release asset](https://developer.github.com/v3/repos/releases/#upload-a-release-asset). This Workflow example assumes you have the [`@actions/create-release`](https://www.github.com/actions/create-release) Action in a previous step:
 
 ```yaml
@@ -62,7 +62,41 @@ jobs:
           asset_content_type: application/zip
 ```
 
-This will upload a release artifact to an existing release, outputting the `browser_download_url` for the asset which could be handled by a third party service, or by GitHub Actions for additional uses. For more information, see the GitHub Documentation for the [upload a release asset](https://developer.github.com/v3/repos/releases/#upload-a-release-asset) endpoint. 
+This will create a release and upload a release artifact to it, outputting the `browser_download_url` for the asset which could be handled by a third party service, or by GitHub Actions for additional uses. 
+
+### Example workflow - upload a release asset to an existing release
+On every `release` of type `creation`, [upload a release asset](https://developer.github.com/v3/repos/releases/#upload-a-release-asset). This Workflow example assumes you have created manually the release, since the workflow is not triggered if the release has been created programmatically:
+
+```yaml
+on:
+  release:
+    types:
+      - created
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Build project # This would actually build your project, using zip for an example artifact
+        run: |
+          zip --junk-paths my-artifact README.md
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{  github.event.release.upload_url }} # this step leverage [github context](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#example-printing-context-information-to-the-log-file) to retrieve update_url 
+          asset_path: ./my-artifact.zip
+          asset_name: my-artifact.zip
+          asset_content_type: application/zip
+```
+
+This will upload a release artifact to an existing release, outputting the `browser_download_url` for the asset which could be handled by a third party service, or by GitHub Actions for additional uses. 
+
+For more information, see the GitHub Documentation for the [upload a release asset](https://developer.github.com/v3/repos/releases/#upload-a-release-asset) endpoint. 
 
 ## Contributing
 We would love you to contribute to `@actions/upload-release-asset`, pull requests are welcome! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) for more information.


### PR DESCRIPTION
The documentation was not covering an important  use-case regarding uploading artifacts to already existing releases.

I believe that would help a log new users of the action